### PR TITLE
fix!: Refactor resources params to reflect better API payload structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 /vendor/bundle
 /lib/bundler/man/
 Gemfile.lock
+.rspec_status
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,6 @@ Gemspec/DevelopmentDependencies:
 
 Gemspec/RequireMFA:
   Enabled: false
+
+Naming/VariableName:
+  Enabled: false

--- a/lib/openpix/ruby_sdk/api_body_formatter.rb
+++ b/lib/openpix/ruby_sdk/api_body_formatter.rb
@@ -12,7 +12,7 @@ module Openpix
           formatted_entity = {}
 
           entity.each do |attr, value|
-            formatted_entity[transform_id_pattern(attr)] = value
+            formatted_entity[attr] = value
           end
 
           remove_empty_values(formatted_entity)
@@ -22,10 +22,6 @@ module Openpix
           entity.compact.reject do |_key, value|
             value.empty? if value.respond_to?(:empty?)
           end
-        end
-
-        def transform_id_pattern(attr_key)
-          attr_key.camelize(:lower).gsub('Id', 'ID')
         end
       end
     end

--- a/lib/openpix/ruby_sdk/api_body_formatter.rb
+++ b/lib/openpix/ruby_sdk/api_body_formatter.rb
@@ -8,16 +8,6 @@ module Openpix
     # Helper class to format body params before request
     class ApiBodyFormatter
       class << self
-        def format_entity_param(entity)
-          formatted_entity = {}
-
-          entity.each do |attr, value|
-            formatted_entity[attr] = value
-          end
-
-          remove_empty_values(formatted_entity)
-        end
-
         def remove_empty_values(entity)
           entity.compact.reject do |_key, value|
             value.empty? if value.respond_to?(:empty?)

--- a/lib/openpix/ruby_sdk/resources/charge.rb
+++ b/lib/openpix/ruby_sdk/resources/charge.rb
@@ -9,18 +9,18 @@ module Openpix
       # Make API operations on Charge resource
       class Charge < Resource
         ATTRS = %w[
-          correlation_id
+          correlationID
           value
           type
           comment
           identifier
-          expires_in
+          expiresIn
           customer
-          days_for_due_date
-          days_after_due_date
+          daysForDueDate
+          daysAfterDueDate
           interests
           fines
-          additional_info
+          additionalInfo
         ].freeze
 
         attr_accessor(*ATTRS)
@@ -47,11 +47,11 @@ module Openpix
 
           return body if body['customer'].nil? || body['customer'].empty?
 
-          body['customer'] = Openpix::RubySdk::ApiBodyFormatter.format_entity_param(body['customer'])
+          body['customer'] = Openpix::RubySdk::ApiBodyFormatter.remove_empty_values(body['customer'])
 
           return body if body['customer']['address'].nil? || body['customer']['address'].empty?
 
-          customer_address_parsed = Openpix::RubySdk::ApiBodyFormatter.format_entity_param(body['customer']['address'])
+          customer_address_parsed = Openpix::RubySdk::ApiBodyFormatter.remove_empty_values(body['customer']['address'])
           body['customer'] = body['customer'].merge({ 'address' => customer_address_parsed })
 
           body
@@ -61,9 +61,9 @@ module Openpix
         # @param key [String] the key
         # @param value [String] the value
         def add_additional_info(key, value)
-          @additional_info = [] if @additional_info.nil?
+          @additionalInfo = [] if @additionalInfo.nil?
 
-          @additional_info << { 'key' => key, 'value' => value }
+          @additionalInfo << { 'key' => key, 'value' => value }
         end
 
         # set interests configuration for creating this resource

--- a/lib/openpix/ruby_sdk/resources/customer.rb
+++ b/lib/openpix/ruby_sdk/resources/customer.rb
@@ -12,8 +12,8 @@ module Openpix
           name
           email
           phone
-          tax_id
-          correlation_id
+          taxID
+          correlationID
           address
         ].freeze
 
@@ -38,7 +38,7 @@ module Openpix
 
           return body if body['address'].nil? || body['address'].empty?
 
-          body['address'] = Openpix::RubySdk::ApiBodyFormatter.format_entity_param(body['address'])
+          body['address'] = Openpix::RubySdk::ApiBodyFormatter.remove_empty_values(body['address'])
 
           body
         end

--- a/lib/openpix/ruby_sdk/resources/payment.rb
+++ b/lib/openpix/ruby_sdk/resources/payment.rb
@@ -12,10 +12,10 @@ module Openpix
       class Payment < Resource
         ATTRS = %w[
           value
-          destination_alias
-          correlation_id
+          destinationAlias
+          correlationID
           comment
-          source_account_id
+          sourceAccountId
         ].freeze
 
         attr_accessor(*ATTRS)
@@ -32,16 +32,6 @@ module Openpix
 
         def to_url
           'payment'
-        end
-
-        def to_body
-          body = super
-
-          return body unless body['sourceAccountID']
-
-          body['sourceAccountId'] = body['sourceAccountID']
-
-          body.except('sourceAccountID')
         end
 
         # rubocop:disable Lint/UnusedMethodArgument

--- a/lib/openpix/ruby_sdk/resources/refund.rb
+++ b/lib/openpix/ruby_sdk/resources/refund.rb
@@ -12,8 +12,8 @@ module Openpix
       class Refund < Resource
         ATTRS = %w[
           value
-          transaction_end_to_end_id
-          correlation_id
+          transactionEndToEndId
+          correlationID
           comment
         ].freeze
 
@@ -31,16 +31,6 @@ module Openpix
 
         def to_url
           'refund'
-        end
-
-        def to_body
-          body = super
-
-          return body unless body['transactionEndToEndID']
-
-          body['transactionEndToEndId'] = body['transactionEndToEndID']
-
-          body.except('transactionEndToEndID')
         end
 
         # rubocop:disable Lint/UnusedMethodArgument

--- a/lib/openpix/ruby_sdk/resources/resource.rb
+++ b/lib/openpix/ruby_sdk/resources/resource.rb
@@ -70,7 +70,7 @@ module Openpix
           body = {}
 
           create_attributes.each do |attr|
-            body[Openpix::RubySdk::ApiBodyFormatter.transform_id_pattern(attr)] = send(attr)
+            body[attr] = send(attr)
           end
 
           compacted_body = Openpix::RubySdk::ApiBodyFormatter.remove_empty_values(body)

--- a/lib/openpix/ruby_sdk/resources/subscription.rb
+++ b/lib/openpix/ruby_sdk/resources/subscription.rb
@@ -10,8 +10,9 @@ module Openpix
       class Subscription < Resource
         ATTRS = %w[
           value
-          day_generate_charge
+          dayGenerateCharge
           customer
+          chargeType
         ].freeze
 
         attr_accessor(*ATTRS)
@@ -39,7 +40,7 @@ module Openpix
 
           return body if body['customer'].nil? || body['customer'].empty?
 
-          body['customer'] = Openpix::RubySdk::ApiBodyFormatter.format_entity_param(body['customer'])
+          body['customer'] = Openpix::RubySdk::ApiBodyFormatter.remove_empty_values(body['customer'])
 
           body
         end

--- a/lib/openpix/ruby_sdk/resources/webhook.rb
+++ b/lib/openpix/ruby_sdk/resources/webhook.rb
@@ -12,7 +12,7 @@ module Openpix
           event
           url
           authorization
-          is_active
+          isActive
         ].freeze
 
         attr_accessor(*ATTRS)

--- a/spec/openpix/ruby_sdk/resources/charge_spec.rb
+++ b/spec/openpix/ruby_sdk/resources/charge_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
   savable_params = {
     resource_class: described_class,
     attrs: {
-      'correlation_id' => '123',
+      'correlationID' => '123',
       'value' => 500
     },
     body_response: {
@@ -69,7 +69,7 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
   let(:customer) { nil }
   let(:attrs) do
     {
-      'correlation_id' => '123',
+      'correlationID' => '123',
       'value' => 500,
       'customer' => customer
     }
@@ -89,7 +89,7 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
     it 'sets the attrs defined by the ATTRS constant' do
       subject.init_body(params: attrs)
 
-      expect(subject.correlation_id).to eq(attrs['correlation_id'])
+      expect(subject.correlationID).to eq(attrs['correlationID'])
       expect(subject.value).to eq(attrs['value'])
       expect(subject.customer).to eq(attrs['customer'])
       expect(subject.comment).to eq(nil)
@@ -102,7 +102,7 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
     context 'without customer' do
       let(:expected_body) do
         {
-          'correlationID' => attrs['correlation_id'],
+          'correlationID' => attrs['correlationID'],
           'value' => attrs['value']
         }
       end
@@ -116,7 +116,7 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
       let(:customer) { {} }
       let(:expected_body) do
         {
-          'correlationID' => attrs['correlation_id'],
+          'correlationID' => attrs['correlationID'],
           'value' => attrs['value']
         }
       end
@@ -131,7 +131,7 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
       let(:customer) do
         {
           name: 'My Name',
-          tax_id: '44406223412',
+          taxID: '44406223412',
           address: address
         }
       end
@@ -139,11 +139,11 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
       context 'without address' do
         let(:expected_body) do
           {
-            'correlationID' => attrs['correlation_id'],
+            'correlationID' => attrs['correlationID'],
             'value' => attrs['value'],
             'customer' => {
               'name' => customer[:name],
-              'taxID' => customer[:tax_id]
+              'taxID' => customer[:taxID]
             }
           }
         end
@@ -157,11 +157,11 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
         let(:address) { {} }
         let(:expected_body) do
           {
-            'correlationID' => attrs['correlation_id'],
+            'correlationID' => attrs['correlationID'],
             'value' => attrs['value'],
             'customer' => {
               'name' => customer[:name],
-              'taxID' => customer[:tax_id]
+              'taxID' => customer[:taxID]
             }
           }
         end
@@ -182,11 +182,11 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
         end
         let(:expected_body) do
           {
-            'correlationID' => attrs['correlation_id'],
+            'correlationID' => attrs['correlationID'],
             'value' => attrs['value'],
             'customer' => {
               'name' => customer[:name],
-              'taxID' => customer[:tax_id],
+              'taxID' => customer[:taxID],
               'address' => {
                 'country' => address[:country],
                 'zipcode' => address[:zipcode],
@@ -208,11 +208,11 @@ RSpec.describe Openpix::RubySdk::Resources::Charge do
     before { subject.init_body(params: attrs) }
 
     it 'adds a new key value pair to the additional_info request body' do
-      expect(subject.additional_info).to be_nil
+      expect(subject.additionalInfo).to be_nil
 
       subject.add_additional_info('venda', 'shiba blocks toy')
 
-      expect(subject.additional_info).to eq([{ 'key' => 'venda', 'value' => 'shiba blocks toy' }])
+      expect(subject.additionalInfo).to eq([{ 'key' => 'venda', 'value' => 'shiba blocks toy' }])
     end
   end
 

--- a/spec/openpix/ruby_sdk/resources/customer_spec.rb
+++ b/spec/openpix/ruby_sdk/resources/customer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Openpix::RubySdk::Resources::Customer do
     resource_class: described_class,
     attrs: {
       'name' => 'My Name',
-      'tax_id' => '99812628000159'
+      'taxID' => '99812628000159'
     },
     body_response: {
       'customer' => {
@@ -70,7 +70,7 @@ RSpec.describe Openpix::RubySdk::Resources::Customer do
   let(:attrs) do
     {
       'name' => 'My Name',
-      'tax_id' => '99812628000159',
+      'taxID' => '99812628000159',
       'address' => address
     }
   end
@@ -90,7 +90,7 @@ RSpec.describe Openpix::RubySdk::Resources::Customer do
       subject.init_body(params: attrs)
 
       expect(subject.name).to eq(attrs['name'])
-      expect(subject.tax_id).to eq(attrs['tax_id'])
+      expect(subject.taxID).to eq(attrs['taxID'])
       expect(subject.email).to eq(nil)
     end
   end
@@ -102,7 +102,7 @@ RSpec.describe Openpix::RubySdk::Resources::Customer do
       let(:expected_body) do
         {
           'name' => attrs['name'],
-          'taxID' => attrs['tax_id']
+          'taxID' => attrs['taxID']
         }
       end
 
@@ -116,7 +116,7 @@ RSpec.describe Openpix::RubySdk::Resources::Customer do
       let(:expected_body) do
         {
           'name' => attrs['name'],
-          'taxID' => attrs['tax_id']
+          'taxID' => attrs['taxID']
         }
       end
 
@@ -137,7 +137,7 @@ RSpec.describe Openpix::RubySdk::Resources::Customer do
       let(:expected_body) do
         {
           'name' => attrs['name'],
-          'taxID' => attrs['tax_id'],
+          'taxID' => attrs['taxID'],
           'address' => {
             'country' => address[:country],
             'zipcode' => address[:zipcode],

--- a/spec/openpix/ruby_sdk/resources/payment_spec.rb
+++ b/spec/openpix/ruby_sdk/resources/payment_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Openpix::RubySdk::Resources::Payment do
     resource_class: described_class,
     attrs: {
       'value' => 54_005,
-      'correlation_id' => '1234',
-      'source_account_id' => '123'
+      'correlationID' => '1234',
+      'sourceAccountId' => '123'
     },
     body_response: {
       'payment' => {
@@ -64,12 +64,12 @@ RSpec.describe Openpix::RubySdk::Resources::Payment do
 
   it_behaves_like 'not destroyable resource', described_class
 
-  let(:source_account_id) { nil }
+  let(:sourceAccountId) { nil }
   let(:attrs) do
     {
       'value' => 54_005,
-      'correlation_id' => '1234',
-      'source_account_id' => source_account_id
+      'correlationID' => '1234',
+      'sourceAccountId' => sourceAccountId
     }
   end
 
@@ -88,8 +88,8 @@ RSpec.describe Openpix::RubySdk::Resources::Payment do
       subject.init_body(params: attrs)
 
       expect(subject.value).to eq(attrs['value'])
-      expect(subject.correlation_id).to eq(attrs['correlation_id'])
-      expect(subject.source_account_id).to eq(source_account_id)
+      expect(subject.correlationID).to eq(attrs['correlationID'])
+      expect(subject.sourceAccountId).to eq(sourceAccountId)
       expect(subject.comment).to eq(nil)
     end
   end
@@ -97,11 +97,11 @@ RSpec.describe Openpix::RubySdk::Resources::Payment do
   describe '#to_body' do
     before { subject.init_body(params: attrs) }
 
-    context 'without source_account_id' do
+    context 'without sourceAccountId' do
       let(:expected_body) do
         {
           'value' => attrs['value'],
-          'correlationID' => attrs['correlation_id']
+          'correlationID' => attrs['correlationID']
         }
       end
 
@@ -110,17 +110,17 @@ RSpec.describe Openpix::RubySdk::Resources::Payment do
       end
     end
 
-    context 'with source_account_id' do
-      let(:source_account_id) { '123' }
+    context 'with sourceAccountId' do
+      let(:sourceAccountId) { '123' }
       let(:expected_body) do
         {
           'value' => attrs['value'],
-          'correlationID' => attrs['correlation_id'],
-          'sourceAccountId' => attrs['source_account_id']
+          'correlationID' => attrs['correlationID'],
+          'sourceAccountId' => attrs['sourceAccountId']
         }
       end
 
-      it 'parses source_account_id as expected' do
+      it 'parses sourceAccountId as expected' do
         expect(subject.to_body).to eq(expected_body)
       end
     end

--- a/spec/openpix/ruby_sdk/resources/refund_spec.rb
+++ b/spec/openpix/ruby_sdk/resources/refund_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Openpix::RubySdk::Resources::Refund do
     resource_class: described_class,
     attrs: {
       'value' => 4000,
-      'correlation_id' => '1234',
-      'transaction_end_to_end_id' => '123'
+      'correlationID' => '1234',
+      'transactionEndToEndId' => '123'
     },
     body_response: {
       'refund' => {
@@ -67,12 +67,12 @@ RSpec.describe Openpix::RubySdk::Resources::Refund do
 
   it_behaves_like 'not destroyable resource', described_class
 
-  let(:transaction_end_to_end_id) { nil }
+  let(:transactionEndToEndId) { nil }
   let(:attrs) do
     {
       'value' => 4000,
-      'correlation_id' => '1234',
-      'transaction_end_to_end_id' => transaction_end_to_end_id
+      'correlationID' => '1234',
+      'transactionEndToEndId' => transactionEndToEndId
     }
   end
 
@@ -91,8 +91,8 @@ RSpec.describe Openpix::RubySdk::Resources::Refund do
       subject.init_body(params: attrs)
 
       expect(subject.value).to eq(attrs['value'])
-      expect(subject.correlation_id).to eq(attrs['correlation_id'])
-      expect(subject.transaction_end_to_end_id).to eq(transaction_end_to_end_id)
+      expect(subject.correlationID).to eq(attrs['correlationID'])
+      expect(subject.transactionEndToEndId).to eq(transactionEndToEndId)
       expect(subject.comment).to eq(nil)
     end
   end
@@ -100,11 +100,11 @@ RSpec.describe Openpix::RubySdk::Resources::Refund do
   describe '#to_body' do
     before { subject.init_body(params: attrs) }
 
-    context 'without transaction_end_to_end_id' do
+    context 'without transactionEndToEndId' do
       let(:expected_body) do
         {
           'value' => attrs['value'],
-          'correlationID' => attrs['correlation_id']
+          'correlationID' => attrs['correlationID']
         }
       end
 
@@ -113,17 +113,17 @@ RSpec.describe Openpix::RubySdk::Resources::Refund do
       end
     end
 
-    context 'with transaction_end_to_end_id' do
-      let(:transaction_end_to_end_id) { '123' }
+    context 'with transactionEndToEndId' do
+      let(:transactionEndToEndId) { '123' }
       let(:expected_body) do
         {
           'value' => attrs['value'],
-          'correlationID' => attrs['correlation_id'],
-          'transactionEndToEndId' => attrs['transaction_end_to_end_id']
+          'correlationID' => attrs['correlationID'],
+          'transactionEndToEndId' => attrs['transactionEndToEndId']
         }
       end
 
-      it 'parses transaction_end_to_end_id as expected' do
+      it 'parses transactionEndToEndId as expected' do
         expect(subject.to_body).to eq(expected_body)
       end
     end

--- a/spec/openpix/ruby_sdk/resources/shared/destroyable_resource.rb
+++ b/spec/openpix/ruby_sdk/resources/shared/destroyable_resource.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 RSpec.shared_examples 'destroyable resource' do |params|
   let(:mocked_http_client) { double('http_client') }
   let(:resource) { params[:resource_class].new(mocked_http_client) }

--- a/spec/openpix/ruby_sdk/resources/shared/findable_resource.rb
+++ b/spec/openpix/ruby_sdk/resources/shared/findable_resource.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 RSpec.shared_examples 'findable resource' do |params|
   let(:mocked_http_client) { double('http_client') }
   let(:resource) { params[:resource_class].new(mocked_http_client) }

--- a/spec/openpix/ruby_sdk/resources/subscription_spec.rb
+++ b/spec/openpix/ruby_sdk/resources/subscription_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Openpix::RubySdk::Resources::Subscription do
       'value' => 4000,
       'customer' => {
         'name' => 'Customer Name',
-        'tax_id' => '31324227036'
+        'taxID' => '31324227036'
       }
     },
     body_response: {
@@ -66,7 +66,7 @@ RSpec.describe Openpix::RubySdk::Resources::Subscription do
       'value' => 4000,
       'customer' => {
         'name' => 'Customer Name',
-        'tax_id' => '31324227036'
+        'taxID' => '31324227036'
       }
     }
   end
@@ -87,7 +87,7 @@ RSpec.describe Openpix::RubySdk::Resources::Subscription do
 
       expect(subject.value).to eq(attrs['value'])
       expect(subject.customer).to eq(attrs['customer'])
-      expect(subject.day_generate_charge).to eq(nil)
+      expect(subject.dayGenerateCharge).to eq(nil)
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe Openpix::RubySdk::Resources::Subscription do
         'value' => attrs['value'],
         'customer' => {
           'name' => attrs['customer']['name'],
-          'taxID' => attrs['customer']['tax_id']
+          'taxID' => attrs['customer']['taxID']
         }
       }
     end

--- a/spec/openpix/ruby_sdk/resources/webhook_spec.rb
+++ b/spec/openpix/ruby_sdk/resources/webhook_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Openpix::RubySdk::Resources::Webhook do
       'event' => 'OPENPIX:CHARGE_CREATED',
       'url' => 'https://mycompany.com.br/webhook',
       'authorization' => 'openpix',
-      'is_active' => false
+      'isActive' => false
     },
     body_response: {
       'webhook' => {
@@ -72,7 +72,7 @@ RSpec.describe Openpix::RubySdk::Resources::Webhook do
       'event' => 'OPENPIX:CHARGE_CREATED',
       'url' => 'https://mycompany.com.br/webhook',
       'authorization' => 'openpix',
-      'is_active' => false
+      'isActive' => false
     }
   end
 
@@ -94,7 +94,7 @@ RSpec.describe Openpix::RubySdk::Resources::Webhook do
       expect(subject.event).to eq(attrs['event'])
       expect(subject.url).to eq(attrs['url'])
       expect(subject.authorization).to eq(attrs['authorization'])
-      expect(subject.is_active).to eq(attrs['is_active'])
+      expect(subject.isActive).to eq(attrs['isActive'])
     end
   end
 
@@ -107,7 +107,7 @@ RSpec.describe Openpix::RubySdk::Resources::Webhook do
           'name' => attrs['name'],
           'url' => attrs['url'],
           'authorization' => attrs['authorization'],
-          'isActive' => attrs['is_active'],
+          'isActive' => attrs['isActive'],
           'event' => attrs['event']
         }
       }


### PR DESCRIPTION
Although it is not a Ruby community standard, we are letting the params for resources look closer like they are in the payload for the API request.